### PR TITLE
List all style names in the collection root endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ DiceBear library.
 
 ## [Unreleased]
 
+### Added
+
+- The version root endpoint (e.g. `/10.x`) now returns the list of available
+  style names as `{ "styles": [...] }`, sorted alphabetically, so clients can
+  discover supported styles. The response is cached via the new
+  `CACHE_CONTROL_STYLES` environment variable (default 1 hour).
+
 ## [4.6.0] - 2026-06-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ npm start
 | `WORKERS`                          | `1`         | Number of Node.js worker threads.                          |
 | `VERSIONS`                         | `10`        | Comma-separated list of supported DiceBear major versions. |
 | `CACHE_CONTROL_AVATARS`            | `31536000`  | Cache duration for avatar responses in seconds (1 year).   |
+| `CACHE_CONTROL_STYLES`             | `3600`      | Cache duration for the styles listing in seconds (1 hour). |
 | `PNG`                              | `1`         | Enable the PNG endpoint (1 = on, 0 = off).                 |
 | `PNG_SIZE_MIN`                     | `1`         | Minimum allowed PNG size in px.                            |
 | `PNG_SIZE_MAX`                     | `256`       | Maximum allowed PNG size in px.                            |

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ export const config: Config = {
   versions: process.env.VERSIONS?.split(',').map(Number) ?? [10],
   cacheControl: {
     avatar: Number(process.env.CACHE_CONTROL_AVATARS ?? 60 * 60 * 24 * 365),
+    styles: Number(process.env.CACHE_CONTROL_STYLES ?? 60 * 60),
   },
   excludedOptions: (
     process.env.EXCLUDED_OPTIONS ?? 'idRandomization,fontFamily,fontWeight,title'

--- a/src/routes/collection.ts
+++ b/src/routes/collection.ts
@@ -1,6 +1,7 @@
 import type { FastifyPluginCallback } from 'fastify';
 import type { StyleEntry } from '../types.js';
 import { styleRoutes } from './style.js';
+import { config } from '../config.js';
 
 type Options = {
   styles: Map<string, StyleEntry>;
@@ -11,7 +12,29 @@ export const collectionRoutes: FastifyPluginCallback<Options> = (
   { styles },
   done,
 ) => {
-  app.get('/', async () => ({ styles: [...styles.keys()] }));
+  const styleNames = [...styles.keys()].sort();
+
+  app.get(
+    '/',
+    {
+      schema: {
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              styles: { type: 'array', items: { type: 'string' } },
+            },
+            required: ['styles'],
+          },
+        },
+      },
+    },
+    async (_request, reply) => {
+      reply.header('Cache-Control', `max-age=${config.cacheControl.styles}`);
+
+      return { styles: styleNames };
+    },
+  );
 
   for (const [name, entry] of styles) {
     app.register(styleRoutes, {

--- a/src/routes/collection.ts
+++ b/src/routes/collection.ts
@@ -11,6 +11,8 @@ export const collectionRoutes: FastifyPluginCallback<Options> = (
   { styles },
   done,
 ) => {
+  app.get('/', async () => ({ styles: [...styles.keys()] }));
+
   for (const [name, entry] of styles) {
     app.register(styleRoutes, {
       prefix: `/${name}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export type Config = {
   };
   cacheControl: {
     avatar: number;
+    styles: number;
   };
   queryString: {
     arrayLimitMin: number;

--- a/tests/http.test.js
+++ b/tests/http.test.js
@@ -326,6 +326,18 @@ describe('options validation', () => {
   });
 });
 
+describe('styles listing', () => {
+  test('returns list of style names for a version', async () => {
+    const res = await server.inject({ method: 'GET', path: '/10.x' });
+    const body = JSON.parse(res.body);
+
+    assert.equal(res.statusCode, 200);
+    assert.ok(Array.isArray(body.styles));
+    assert.ok(body.styles.length > 0);
+    assert.ok(body.styles.includes('initials'));
+  });
+});
+
 describe('schema.json endpoint removed', () => {
   test('returns 404 for schema.json', async () => {
     const res = await server.inject({ method: 'GET', path: '/10.x/avataaars/schema.json' });

--- a/tests/http.test.js
+++ b/tests/http.test.js
@@ -334,7 +334,21 @@ describe('styles listing', () => {
     assert.equal(res.statusCode, 200);
     assert.ok(Array.isArray(body.styles));
     assert.ok(body.styles.length > 0);
+    assert.ok(body.styles.every((name) => typeof name === 'string'));
     assert.ok(body.styles.includes('initials'));
+  });
+
+  test('returns style names sorted alphabetically', async () => {
+    const res = await server.inject({ method: 'GET', path: '/10.x' });
+    const body = JSON.parse(res.body);
+
+    assert.deepEqual(body.styles, [...body.styles].sort());
+  });
+
+  test('sets a cache-control header', async () => {
+    const res = await server.inject({ method: 'GET', path: '/10.x' });
+
+    assert.match(res.headers['cache-control'], /max-age=\d+/);
   });
 });
 


### PR DESCRIPTION
Before, it was impossible for API clients to get a list of all available style names.

Now, the endpoint "/" serves an array of all style names like so:

    {"styles":["avataars"]}