### PR TITLE
Add JSDoc comment to collectionRoutes function

### DIFF
--- a/src/routes/collection.ts
+++ b/src/routes/collection.ts
@@ -7,6 +7,11 @@ type Options = {
   styles: Map<string, StyleEntry>;
 };
 
+/**
+ * Fastify plugin for registering collection-level routes.
+ * Registers a GET endpoint to retrieve a sorted list of style names,
+ * and sub-routes for each style using the styleRoutes plugin.
+ */
 export const collectionRoutes: FastifyPluginCallback<Options> = (
   app,
   { styles },


### PR DESCRIPTION
## Problem
The `collectionRoutes` public function in `src/routes/collection.ts` lacks JSDoc comments, which hinders quick understanding of its purpose, parameters, and behavior as a Fastify plugin.

## Solution
Added a JSDoc comment to the `collectionRoutes` function to document that it is a Fastify plugin for registering collection-level routes, including a GET endpoint to retrieve a sorted list of style names and sub-routes for each style using the `styleRoutes` plugin.

## Verification
- Ensure the code compiles without errors by running the TypeScript compiler.
- Run existing tests to confirm no functional changes were introduced.
- Review the added JSDoc comment for accuracy and consistency with project documentation standards.